### PR TITLE
Initialize suspended base on the suspend-on-start config value

### DIFF
--- a/src/WatchSuspendPlugin.ts
+++ b/src/WatchSuspendPlugin.ts
@@ -16,9 +16,9 @@ export class WatchSuspendPlugin {
     jestHooks.shouldRunTestSuite(() => {
       if (this.firstRun) {
         firstRun = this.firstRun = false
-        if (this.config['suspend-on-start']) {
-          this.log(chalk.bold('\nTest is suspended on start.'))
-          return false
+        if (this.suspend) {
+          this.log(chalk.bold('\nTest is suspended on start.'))          
+          return this.suspend = false
         }
         return true
       }

--- a/src/WatchSuspendPlugin.ts
+++ b/src/WatchSuspendPlugin.ts
@@ -17,7 +17,7 @@ export class WatchSuspendPlugin {
       if (this.firstRun) {
         firstRun = this.firstRun = false
         if (this.suspend) {
-          this.log(chalk.bold('\nTest is suspended on start.'))          
+          this.log(chalk.bold('\nTest is suspended on start.'))
           return this.suspend = false
         }
         return true

--- a/src/WatchSuspendPlugin.ts
+++ b/src/WatchSuspendPlugin.ts
@@ -8,6 +8,7 @@ export class WatchSuspendPlugin {
   suspend: boolean
   constructor({ config }) {
     this.config = { key: 's', prompt: 'suspend watch mode', ...config }
+    this.suspend = this.config['suspend-on-start'];
   }
 
   // Add hooks to Jest lifecycle events

--- a/src/WatchSuspendPlugin.ts
+++ b/src/WatchSuspendPlugin.ts
@@ -18,7 +18,8 @@ export class WatchSuspendPlugin {
         firstRun = this.firstRun = false
         if (this.suspend) {
           this.log(chalk.bold('\nTest is suspended on start.'))
-          return this.suspend = false
+          this.suspend = false
+          return false
         }
         return true
       }


### PR DESCRIPTION
I've been investigating #5 and https://github.com/facebook/jest/issues/7038

I might be totally wrong, but it seems to me that the issue is that `this.suspend` is not initialized based on the `suspend-on-start` value, which causes `shouldRunTestSuite` to return true after the first invocation.

There is still a failing test in this PR but I wonder if the behavior described in the test is the expected behavior